### PR TITLE
Feat: 랭킹 페이지 추가

### DIFF
--- a/api/getAllMatches.ts
+++ b/api/getAllMatches.ts
@@ -1,0 +1,85 @@
+import axios from "axios"
+import dayjs from "dayjs"
+import { useQuery } from "react-query"
+
+import type {
+  QueryFunction,
+  QueryFunctionContext,
+  UseQueryOptions,
+} from "react-query"
+import type { AllMatches, IQueryKey, Result } from "~/types/getAllMatches"
+import type { MatchDetail } from "~/types/getMatchDetail"
+
+const matchTypeHash = {
+  indi: "7b9f0fd5377c38514dbb78ebe63ac6c3b81009d5a31dd569d1cff8f005aa881a",
+  team: "effd66758144a29868663aa50e85d3d95c5bc0147d7fdb9802691c2087f3416e",
+}
+
+const nexonAxios = axios.create({
+  baseURL: "/api",
+  headers: {
+    Authorization: process.env.API_KEY as string,
+  },
+})
+
+export const getAllMatches = async (ctx: QueryFunctionContext<IQueryKey[]>) => {
+  const { matchType } = ctx.queryKey[0]
+  const start = dayjs().startOf("day")
+  const end = dayjs().endOf("day")
+  const result: Result = []
+
+  // get recent 50 match ids
+  const allMatchRes = await nexonAxios.get<AllMatches>("/matches/all", {
+    params: {
+      start_date: start,
+      end_date: end,
+      limit: 200,
+      match_types: matchTypeHash[matchType],
+    },
+  })
+
+  // convert to match detail
+  const res = await Promise.all(
+    allMatchRes.data.matches[0].matches.map((id) =>
+      nexonAxios.get<MatchDetail>(`/matches/${id}`)
+    )
+  )
+
+  res.forEach((r) => {
+    if (r.data.players) {
+      if (r.data.players.length < 8) return
+      r.data.players.forEach((p) =>
+        result.push({
+          channelName: r.data.channelName,
+          characterName: p.characterName,
+          matchWin: Number(p.matchWin),
+          matchRank: Number(p.matchRank),
+        })
+      )
+    } else {
+      r.data.teams.forEach((t) => {
+        if (!t.players) return
+        if (t.players.length < 4) return
+        t.players.forEach((p) => {
+          result.push({
+            channelName: r.data.channelName,
+            characterName: p.characterName,
+            matchWin: Number(p.matchWin),
+            matchRank: Number(p.matchRank),
+          })
+        })
+      })
+    }
+  })
+
+  return result
+}
+
+export const useAMQuery = (
+  key: IQueryKey[],
+  fetcher: QueryFunction<Result, IQueryKey[]>,
+  opt?: Omit<
+    UseQueryOptions<Result, unknown, Result, IQueryKey[]>,
+    "queryKey" | "queryFn"
+  >
+) => useQuery<Result, unknown, Result, IQueryKey[]>(key, fetcher, opt)

--- a/api/getUserProfile.ts
+++ b/api/getUserProfile.ts
@@ -60,7 +60,7 @@ export const getUserProfile = async (
 export const useUPQuery = (
   key: IQueryKey[],
   fetcher: QueryFunction<Result, IQueryKey[]>,
-  opt: Omit<
+  opt?: Omit<
     UseQueryOptions<Result, unknown, Result, IQueryKey[]>,
     "queryKey" | "queryFn"
   >

--- a/components/Ranking/Header.tsx
+++ b/components/Ranking/Header.tsx
@@ -1,0 +1,50 @@
+import React from "react"
+import styled from "@emotion/styled"
+import dayjs from "dayjs"
+
+const FORMAT_STR = "YYYY년MM월DD일 HH:mm:ss"
+
+const Header = () => {
+  const today = dayjs()
+  const start = today.startOf("month").format(FORMAT_STR)
+  const end = today.endOf("month").format(FORMAT_STR)
+  const recent = today.startOf("day").format(FORMAT_STR)
+
+  return (
+    <Wrapper>
+      <Title>{today.month() + 1}월 TMI 랭킹</Title>
+      <Seperator />
+      <Detail>
+        랭킹 산정기간 {start} ~ {end}
+      </Detail>
+      <Detail>최근 업데이트 {recent}</Detail>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.section`
+  width: 100%;
+  max-width: 1000px;
+  margin-top: 32px;
+
+  color: white;
+`
+
+const Title = styled.h1`
+  font-size: 22px;
+  font-weight: bold;
+`
+
+const Seperator = styled.div`
+  width: 36px;
+  height: 4px;
+  margin-bottom: 14px;
+  background-color: white;
+`
+
+const Detail = styled.p`
+  margin: 2px 0;
+  font-size: 12px;
+`
+
+export default Header

--- a/components/Ranking/Ranker.tsx
+++ b/components/Ranking/Ranker.tsx
@@ -1,0 +1,172 @@
+import React, { useEffect, useState } from "react"
+import styled from "@emotion/styled"
+import { useNavigate } from "react-router-dom"
+import { ChartOptions } from "chart.js"
+
+import { getUserProfile, useUPQuery } from "~/api/getUserProfile"
+import calcRecords from "~/utils/calcRecords"
+import Graph from "~/components/User/Graph"
+import type { IRecords, TData } from "~/components/User/Records"
+
+interface IRanker {
+  characterName: string
+  matchRank: number
+  point: number
+  matchType: "indi" | "team"
+}
+
+const IMG_BASE = "https://tmi.nexon.com"
+const MEDAL_IMG = [
+  "/img/assets/icon_goldmedal.png",
+  "/img/assets/icon_silvermedal.png",
+  "/img/assets/icon_bronzemedal.png",
+]
+const options: ChartOptions<"doughnut"> = {
+  cutout: "75%",
+  maintainAspectRatio: false,
+  events: [],
+  elements: {
+    arc: {
+      borderWidth: 0,
+    },
+  },
+}
+
+const Ranker = ({ characterName, matchRank, point, matchType }: IRanker) => {
+  const navigate = useNavigate()
+  const [rankerData, setRankerData] = useState<IRecords["data"]>()
+  const { data } = useUPQuery(
+    [{ nick: characterName, matchType }],
+    getUserProfile
+  )
+
+  useEffect(() => {
+    if (!data) return
+    setRankerData(calcRecords(data.matchInfo))
+  }, [data])
+
+  if (!rankerData) return <></>
+  const winRate = Math.round((rankerData.win / rankerData.total) * 100)
+  const winData: TData = {
+    datasets: [
+      {
+        data: [winRate, 100 - winRate],
+        backgroundColor: ["#0077ff", "#ebebeb"],
+      },
+    ],
+    labels: ["승률"],
+  }
+
+  const completeRate = Math.round(
+    (rankerData.complete / rankerData.total) * 100
+  )
+  const retireData: TData = {
+    datasets: [
+      {
+        data: [100 - completeRate, completeRate],
+        backgroundColor: ["#f62459", "#ebebeb"],
+      },
+    ],
+    labels: ["리타이어율"],
+  }
+
+  return (
+    <Wrapper>
+      <Status>
+        <Medal
+          src={`${IMG_BASE}${MEDAL_IMG[matchRank - 1]}`}
+          className={matchRank === 1 ? "gold" : ""}
+        />
+        <Name
+          className="bold"
+          onClick={() => navigate(`/user?nick=${characterName}`)}
+        >
+          {characterName}
+        </Name>
+        <Detail>
+          순위 <span className="bold">{matchRank}위</span>
+        </Detail>
+        <Detail>
+          누적포인트 <span className="bold">{point.toLocaleString()}PT</span>
+        </Detail>
+      </Status>
+      <Graphs>
+        <Graph data={winData} options={options} />
+        <Graph data={retireData} options={options} />
+      </Graphs>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.article`
+  position: relative;
+  width: 240px;
+  height: 250px;
+  border-radius: 10px;
+  background-color: white;
+
+  .bold {
+    font-weight: bold;
+  }
+
+  :hover {
+    color: #0077ff;
+  }
+`
+
+const Status = styled.div`
+  position: relative;
+  height: 130px;
+  border-radius: 10px;
+  padding-top: 36px;
+  padding-left: 40px;
+  padding-bottom: 20px;
+
+  background-image: url("${IMG_BASE}/img/background_flag_rank.png");
+  background-size: cover;
+  background-position: 50%;
+`
+
+const Name = styled.h1`
+  margin: 0;
+  margin-bottom: 12px;
+
+  color: #0077ff;
+  font-size: 18px;
+  cursor: pointer;
+`
+
+const Detail = styled.p`
+  margin: 4px 0;
+
+  font-size: 14px;
+`
+
+const Medal = styled.img`
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  width: 26px;
+  height: 34px;
+
+  transform: translate(0, -50%);
+
+  &.gold {
+    width: 36px;
+    height: 44px;
+  }
+`
+
+const Graphs = styled.div`
+  width: 100%;
+  height: 120px;
+  border-top: 1px solid #0077cc;
+  padding: 0 10px;
+  padding-top: 10px;
+
+  display: grid;
+  grid-template-columns: repeat(2, 70px);
+  justify-content: space-around;
+`
+
+export default Ranker

--- a/components/Ranking/RankingItem.tsx
+++ b/components/Ranking/RankingItem.tsx
@@ -1,0 +1,84 @@
+import React from "react"
+import styled from "@emotion/styled"
+import type { IRanking } from "~/utils/calcRanking"
+import { useNavigate } from "react-router-dom"
+
+interface IRankingItem {
+  rank: number
+  data: IRanking["combine"][0]
+}
+
+const RankingItem = ({ rank, data }: IRankingItem) => {
+  const navigate = useNavigate()
+
+  if (rank === -1) {
+    // render header
+    return (
+      <Header>
+        <li>#</li>
+        <li>닉네임</li>
+        <li>누적포인트</li>
+        <li>주행횟수</li>
+      </Header>
+    )
+  }
+  return (
+    <Wrapper>
+      <li>{rank}</li>
+      <Name
+        onClick={() => {
+          navigate(`/user?nick=${data[0]}`)
+        }}
+      >
+        {data[0]}
+      </Name>
+      <li>{data[1].point} PT</li>
+      <li>{data[1].rounds}회</li>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.ul`
+  width: 1000px;
+  height: 42px;
+  margin: 0;
+  margin-bottom: 10px;
+  border: 1px solid #f2f2f2;
+  padding: 0;
+  padding-left: 60px;
+  background-color: white;
+
+  font-size: 14px;
+
+  display: grid;
+  grid-template-columns: 200px 420px 200px 120px;
+  align-items: center;
+  justify-content: center;
+
+  li {
+    list-style: none;
+  }
+
+  :hover {
+    border: 1px solid #0077ff;
+    color: #0077ff;
+  }
+`
+
+const Header = styled(Wrapper)`
+  border: none;
+  background-color: transparent;
+  color: white;
+  font-size: 12px;
+
+  :hover {
+    border: none;
+    color: white;
+  }
+`
+
+const Name = styled.li`
+  cursor: pointer;
+`
+
+export default RankingItem

--- a/components/Ranking/Tabs.tsx
+++ b/components/Ranking/Tabs.tsx
@@ -1,0 +1,136 @@
+import React, { MouseEvent } from "react"
+import styled from "@emotion/styled"
+import { useSearchParams } from "react-router-dom"
+import { FaUser, FaUsers } from "react-icons/fa"
+
+const Tabs = () => {
+  const [params, setParams] = useSearchParams()
+  const matchType = params.get("matchType") || ""
+  const mode = params.get("mode") || ""
+
+  const matchTypeClasses = {
+    indi: matchType === "indi" ? "active" : "",
+    team: matchType === "team" ? "active" : "",
+  }
+
+  const modeClasses = {
+    combine: mode === "combine" ? "active" : "",
+    fastest: mode === "fastest" ? "active" : "",
+    infinit: mode === "infinit" ? "active" : "",
+  }
+
+  const handleMatchType = (e: MouseEvent<HTMLButtonElement>) => {
+    const target = e.currentTarget
+    params.set("matchType", target.dataset.id as string)
+    setParams(params)
+  }
+
+  const handleMode = (e: MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLButtonElement
+    params.set("mode", target.dataset.id as string)
+    setParams(params)
+  }
+
+  return (
+    <Wrapper>
+      <MatchTypeTabs>
+        <Tab
+          data-id="indi"
+          className={matchTypeClasses.indi}
+          onClick={handleMatchType}
+        >
+          <FaUser />
+          개인전
+        </Tab>
+        <Tab
+          data-id="team"
+          className={matchTypeClasses.team}
+          onClick={handleMatchType}
+        >
+          <FaUsers size={18} />
+          팀전
+        </Tab>
+      </MatchTypeTabs>
+      <Seperator />
+      <ModeTabs onClick={handleMode}>
+        <Tab data-id="combine" className={modeClasses.combine}>
+          통합
+        </Tab>
+        <Tab data-id="fastest" className={modeClasses.fastest}>
+          매빠
+        </Tab>
+        <Tab data-id="infinit" className={modeClasses.infinit}>
+          무부
+        </Tab>
+      </ModeTabs>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.section`
+  width: 100%;
+  max-width: 1000px;
+  margin-top: 16px;
+  background-color: #005fcc;
+
+  display: flex;
+  align-items: center;
+
+  font-size: 12px;
+
+  .active {
+    background-color: white;
+    color: #0077cc;
+  }
+
+  svg {
+    margin-right: 4px;
+  }
+`
+
+const Seperator = styled.div`
+  width: 1px;
+  height: 14px;
+  margin: 0 12px;
+  background-color: white;
+`
+
+const MatchTypeTabs = styled.div`
+  width: 200px;
+  height: 26px;
+
+  display: flex;
+
+  button:first-of-type {
+    border-radius: 6px 0 0 6px;
+  }
+  button:last-of-type {
+    border-radius: 0 6px 6px 0;
+  }
+`
+
+const ModeTabs = styled(MatchTypeTabs)`
+  width: 110px;
+`
+
+const Tab = styled.button`
+  border: 1px solid white;
+  padding: 0;
+  background-color: transparent;
+
+  color: white;
+  user-select: none;
+  cursor: pointer;
+
+  flex-grow: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  :hover {
+    background-color: white;
+    color: #0077cc;
+  }
+`
+
+export default Tabs

--- a/pages/Ranking.tsx
+++ b/pages/Ranking.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useState } from "react"
+import styled from "@emotion/styled"
+import { useSearchParams } from "react-router-dom"
+
+import { getAllMatches, useAMQuery } from "~/api/getAllMatches"
+import calcRanking, { IRanking } from "~/utils/calcRanking"
+
+import Header from "~/components/Ranking/Header"
+import Tabs from "~/components/Ranking/Tabs"
+import Ranker from "~/components/Ranking/Ranker"
+import RankingItem from "~/components/Ranking/RankingItem"
+import Spinner from "~/components/User/Spinner"
+
+type TMatchType = "indi" | "team"
+type TMode = "combine" | "fastest" | "infinit"
+
+const Ranking = () => {
+  const params = useSearchParams()[0]
+  const matchType = (params.get("matchType") as TMatchType) || "indi"
+  const mode = (params.get("mode") as TMode) || "combine"
+  const [rankingData, setRankingData] = useState<IRanking>()
+  const headerData: IRanking["combine"][0] = [
+    "닉네임",
+    { point: -1, rounds: -1 },
+  ]
+
+  const { data } = useAMQuery([{ matchType }], getAllMatches)
+
+  // calc ranking after data fetched
+  useEffect(() => {
+    if (!data) return
+    setRankingData(calcRanking(data, matchType))
+  }, [data, matchType])
+
+  return (
+    <Wrapper>
+      <TopSection>
+        <Header />
+        <Tabs />
+        <TopRankers>
+          {rankingData?.[mode].slice(0, 3).map((d, i) => (
+            <Ranker
+              key={d[0]}
+              characterName={d[0]}
+              matchRank={i + 1}
+              point={d[1].point}
+              matchType={matchType}
+            />
+          ))}
+        </TopRankers>
+      </TopSection>
+      <RankingList>
+        <RankingItem rank={-1} data={headerData} />
+        {rankingData?.[mode].slice(3).map((d, i) => (
+          <RankingItem key={d[0]} rank={i + 4} data={d} />
+        ))}
+      </RankingList>
+      <Spinner show={!data || !rankingData} />
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.section`
+  background-color: #fafafa;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+const TopSection = styled.section`
+  width: 100%;
+  background-color: #005fcc;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+const TopRankers = styled.section`
+  width: 1000px;
+  margin: 64px 0;
+  margin-bottom: 120px;
+
+  display: flex;
+  justify-content: space-evenly;
+`
+
+const RankingList = styled.section`
+  margin-top: -64px;
+`
+
+export default Ranking

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,6 +14,7 @@ import { QueryClientProvider, QueryClient } from "react-query"
 import NavBar from "~/components/NavBar"
 import Home from "./Home"
 import User from "./User"
+import Ranking from "./Ranking"
 
 const globalStyle = css`
   ${normalize}
@@ -60,7 +61,7 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="user" element={<User />} />
-          <Route path="rank" element={<h1>Ranking</h1>} />
+          <Route path="rank" element={<Ranking />} />
           <Route path="track" element={<Track />} />
           <Route path="*" element={<Navigate replace to="/" />} />
         </Routes>

--- a/types/getAllMatches.d.ts
+++ b/types/getAllMatches.d.ts
@@ -1,0 +1,21 @@
+export interface AllMatches {
+  matches: Matches[]
+}
+
+interface Matches {
+  matches: string[]
+  matchType: string
+}
+
+interface IQueryKey {
+  matchType: "indi" | "team"
+}
+
+type Result = MatchData[]
+
+interface MatchData {
+  channelName: string
+  characterName: string
+  matchWin: number
+  matchRank: number
+}

--- a/types/getMatchDetail.d.ts
+++ b/types/getMatchDetail.d.ts
@@ -1,4 +1,5 @@
 export interface MatchDetail {
+  channelName: string
   players: Player[]
   teams: [Team, Team]
 }

--- a/utils/calcRanking.ts
+++ b/utils/calcRanking.ts
@@ -1,0 +1,82 @@
+import type { Result } from "~/types/getAllMatches"
+
+interface Characters {
+  [characterName: string]: {
+    point: number
+    rounds: number
+  }
+}
+
+interface PreResult {
+  combine: Characters
+  fastest: Characters
+  infinit: Characters
+}
+
+export interface IRanking {
+  combine: [string, Characters[string]][]
+  fastest: [string, Characters[string]][]
+  infinit: [string, Characters[string]][]
+}
+
+const INDI_SCORE = [-5, 10, 7, 5, 4, 3, 1, 0, -1]
+const TEAM_SCORE = [0, 10, 8, 6, 5, 4, 3, 2, 1]
+
+const calcRanking = (data: Result, matchType: "indi" | "team") => {
+  const preResult: PreResult = {
+    combine: {},
+    fastest: {},
+    infinit: {},
+  }
+  const result: IRanking = {
+    combine: [],
+    fastest: [],
+    infinit: [],
+  }
+
+  data.forEach((d) => {
+    // determine mode
+    let mode: keyof IRanking | "" = ""
+    if (d.channelName.endsWith("Combine")) {
+      mode = "combine"
+    } else if (d.channelName.endsWith("Fastest")) {
+      mode = "fastest"
+    } else if (d.channelName.endsWith("Infinit")) {
+      mode = "infinit"
+    } else {
+      // continue when mode is not compatible
+      return
+    }
+
+    // calc point
+    let point = 0
+    if (matchType === "indi") {
+      point = INDI_SCORE.at(d.matchRank) || -5
+    } else {
+      point = TEAM_SCORE.at(d.matchRank) || 0
+    }
+
+    // update result
+    if (preResult[mode][d.characterName]) {
+      preResult[mode][d.characterName].point += point
+      preResult[mode][d.characterName].rounds += 1
+    } else {
+      preResult[mode][d.characterName] = {
+        point,
+        rounds: 1,
+      }
+    }
+
+    // sort preResult and save to result
+    Object.keys(preResult).forEach((k) => {
+      const key = k as keyof IRanking
+      result[key] = Object.entries(preResult[key]).sort(
+        (a, b) => b[1].point - a[1].point || b[1].rounds - a[1].rounds
+      )
+    })
+  })
+
+  return result
+}
+
+export default calcRanking


### PR DESCRIPTION
- getAllMatches.ts: 오늘 하루의 매치 중 200개 가져오기
- getUserProfile.ts: opt 인자를 선택요소로 수정
- Header.tsx: 랭킹 페이지 헤더 섹션
- Ranker.tsx: 랭킹 상위 3명용 컴포넌트
- RankingItem.tsx: 랭킹 상위 3명을 제외한 사람들의 순위
- Tabs.tsx: 개인/팀 통합/매빠/무부 선택용 탭
- pages/index.tsx: 랭킹 페이지 추가
- pages/Ranking.tsx: 랭킹 페이지
- getMatchDetail.d.ts: 모드별로 랭킹 산정하기 위해 channelName 추가
- calcRanking.ts: 매치 데이터로 랭킹 산정